### PR TITLE
adding non-cumulative capability to cart.add

### DIFF
--- a/features/shopping_cart.feature
+++ b/features/shopping_cart.feature
@@ -22,6 +22,14 @@ Feature: Shopping Cart
     Then the total for the cart should be "216.48"
     And the total unique items on the cart should be "2"
 
+  Scenario: Add a product to cart twice non-cumulatively
+    When I add product "Apple" to cart with price "99.99"
+    And I add product "Apple" to cart with price "99.99"
+    And I non-cumulatively add product "Apple" to cart with price "99.99"
+    Then the subtotal for the cart should be "99.99"
+    Then the total for the cart should be "108.24"
+    And the total unique items on the cart should be "1"
+
   Scenario: Remove products from cart
     Given I add 3 "Apple" products to cart with price "99.99"
     When I remove 1 "Apple" unit from cart

--- a/features/step_definitions/shopping_cart_steps.rb
+++ b/features/step_definitions/shopping_cart_steps.rb
@@ -17,6 +17,11 @@ When /^I add product "([^"]*)" to cart with price "([^"]*)"$/ do |product_name, 
   @cart.add(product, price)
 end
 
+When /^I non-cumulatively add product "([^"]*)" to cart with price "([^"]*)"$/ do |product_name, price|
+  product = Product.find_by_name(product_name)
+  @cart.add(product, price, 1, false)
+end
+
 Then /^the total unique items on the cart should be "([^"]*)"$/ do |total|
   @cart.reload
   @cart.total_unique_items.should eq(total.to_i)

--- a/lib/active_record/acts/shopping_cart/cart/instance_methods.rb
+++ b/lib/active_record/acts/shopping_cart/cart/instance_methods.rb
@@ -6,13 +6,14 @@ module ActiveRecord
           #
           # Adds a product to the cart
           #
-          def add(object, price, quantity = 1)
+          def add(object, price, quantity = 1, cumulative = true)
             cart_item = item_for(object)
 
             unless cart_item
               shopping_cart_items.create(:item => object, :price => price, :quantity => quantity)
             else
-              cart_item.quantity = (cart_item.quantity + quantity)
+              cumulative = cumulative == true ? cart_item.quantity : 0
+              cart_item.quantity = (cumulative + quantity)
               cart_item.save
             end
           end

--- a/spec/active_record/acts/shopping_cart/cart/instance_methods_spec.rb
+++ b/spec/active_record/acts/shopping_cart/cart/instance_methods_spec.rb
@@ -31,6 +31,17 @@ describe ActiveRecord::Acts::ShoppingCart::Cart::InstanceMethods do
       end
     end
 
+    context "item is not in cart" do
+      before do
+        subject.stub(:item_for).with(object)
+      end
+
+      it "creates a new shopping cart item non-cumulatively" do
+        subject.shopping_cart_items.should_receive(:create).with(:item => object, :price => 19.99, :quantity => 3)
+        subject.add(object, 19.99, 3, false)
+      end
+    end
+
     context "item is already on cart" do
       before do
         subject.stub(:item_for).with(object).and_return(shopping_cart_item)
@@ -39,6 +50,17 @@ describe ActiveRecord::Acts::ShoppingCart::Cart::InstanceMethods do
       it "updates the quantity for the item" do
         shopping_cart_item.should_receive(:quantity=).with(5)
         subject.add(object, 19.99, 3)
+      end
+    end
+
+    context "item is already in cart" do
+      before do
+        subject.stub(:item_for).with(object).and_return(shopping_cart_item)
+      end
+
+      it "updates the quantity for the item non-cumulatively" do
+        shopping_cart_item.should_receive(:quantity=).with(3) # not 5
+        subject.add(object, 19.99, 3, false)
       end
     end
   end


### PR DESCRIPTION
I needed a way to add items such that the final quantity is equal to the amount specified in the `add` method, not the cumulative quantity of that and what is already stored in the db.

This capability is provided by a boolean fourth parameter, called `cumulative`. By default the method will behave as you initially coded it (because by default `cumulative` is set to `true`); however by passing `false`, `cart_item.quantity` will not be included.

I also added tests.
