### PR TITLE
Use ActiveRecord::Acts::ShoppingCart::CollectionItem as the class name, since it is reasonable for the user to want ShoppingCart::Item for her ActiveRecord::Base subclass

### DIFF
--- a/lib/active_record/acts/shopping_cart.rb
+++ b/lib/active_record/acts/shopping_cart.rb
@@ -18,7 +18,7 @@ module ActiveRecord
         #
         def acts_as_shopping_cart_using(item_class)
           self.send :include, ActiveRecord::Acts::ShoppingCart::Collection
-          self.send :include, ActiveRecord::Acts::ShoppingCart::Item
+          self.send :include, ActiveRecord::Acts::ShoppingCart::CollectionItem
           has_many :shopping_cart_items, :class_name => item_class.to_s.classify,
               :as => :owner, :dependent => :destroy
         end

--- a/lib/active_record/acts/shopping_cart/collection_item.rb
+++ b/lib/active_record/acts/shopping_cart/collection_item.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module Acts
     module ShoppingCart
-      module Item
+      module CollectionItem
 
         #
         # Returns the cart item for the specified object

--- a/lib/acts_as_shopping_cart.rb
+++ b/lib/acts_as_shopping_cart.rb
@@ -8,8 +8,8 @@ require 'acts_as_shopping_cart/schema'
 module ActiveRecord
   module Acts
     module ShoppingCart
-      autoload :Collection , 'active_record/acts/shopping_cart/collection'
-      autoload :Item       , 'active_record/acts/shopping_cart/item'
+      autoload :Collection      , 'active_record/acts/shopping_cart/collection'
+      autoload :CollectionItem  , 'active_record/acts/shopping_cart/collection_item'
     end
 
     module ShoppingCartItem

--- a/spec/active_record/acts/shopping_cart/collection_item_spec.rb
+++ b/spec/active_record/acts/shopping_cart/collection_item_spec.rb
@@ -1,9 +1,9 @@
 require File.expand_path(File.dirname(__FILE__) + '../../../../spec_helper')
 
-describe ActiveRecord::Acts::ShoppingCart::Item do
+describe ActiveRecord::Acts::ShoppingCart::CollectionItem do
   let(:klass) do
     klass = Class.new
-    klass.send :include, ActiveRecord::Acts::ShoppingCart::Item
+    klass.send :include, ActiveRecord::Acts::ShoppingCart::CollectionItem
     klass
   end
 


### PR DESCRIPTION
This is a suggestion, I think it would be beneficial. I'm fairly certain this is a non-breaking change, since everything that uses this is internal, but I might be wrong. 