### PR TITLE
Remove custom empty? method in ShoppingCart Collection

### DIFF
--- a/lib/active_record/acts/shopping_cart/collection.rb
+++ b/lib/active_record/acts/shopping_cart/collection.rb
@@ -26,13 +26,6 @@ module ActiveRecord
         end
 
         #
-        # Returns true when the cart is empty
-        #
-        def empty?
-          shopping_cart_items.empty?
-        end
-
-        #
         # Remove an item from the cart
         #
         def remove(object, quantity = 1)

--- a/spec/active_record/acts/shopping_cart/collection_spec.rb
+++ b/spec/active_record/acts/shopping_cart/collection_spec.rb
@@ -77,25 +77,7 @@ describe ActiveRecord::Acts::ShoppingCart::Collection do
 
     it "clears all the items in the cart" do
       subject.clear
-      subject.empty?.should be_true
-    end
-  end
-
-  describe "empty?" do
-    context "cart has items" do
-      before do
-        subject.shopping_cart_items << mock
-      end
-
-      it "returns false" do
-        subject.empty?.should be_false
-      end
-    end
-
-    context "cart is empty" do
-      it "returns true" do
-        subject.empty?.should be_true
-      end
+      subject.shopping_cart_items.empty?.should be_true
     end
   end
 


### PR DESCRIPTION
This creates a couple of issues:
- Affects the use of presence validation for a cart.
- Affects the use of `cart.present?`

See https://github.com/crowdint/acts_as_shopping_cart/issues/40
